### PR TITLE
updated from origin

### DIFF
--- a/lisp/init-clojure-cider.el
+++ b/lisp/init-clojure-cider.el
@@ -7,14 +7,14 @@
 (when (maybe-require-package 'cider)
   (setq nrepl-popup-stacktraces nil)
 
-  (after-load 'cider
+  (with-eval-after-load 'cider
     (add-hook 'cider-repl-mode-hook 'subword-mode)
     (add-hook 'cider-repl-mode-hook 'paredit-mode))
 
   (require-package 'flycheck-clojure)
-  (after-load 'clojure-mode
-    (after-load 'cider
-      (after-load 'flycheck
+  (with-eval-after-load 'clojure-mode
+    (with-eval-after-load 'cider
+      (with-eval-after-load 'flycheck
         (flycheck-clojure-setup)))))
 
 

--- a/lisp/init-clojure.el
+++ b/lisp/init-clojure.el
@@ -8,7 +8,7 @@
   (require-package 'cljsbuild-mode)
   (require-package 'elein)
 
-  (after-load 'clojure-mode
+  (with-eval-after-load 'clojure-mode
     (add-hook 'clojure-mode-hook 'sanityinc/lisp-setup)
     (add-hook 'clojure-mode-hook 'subword-mode)))
 

--- a/lisp/init-common-lisp.el
+++ b/lisp/init-common-lisp.el
@@ -9,7 +9,7 @@
                               (require 'slime)
                               (normal-mode))))
 
-(after-load 'slime
+(with-eval-after-load 'slime
   (when (executable-find "sbcl")
     (add-to-list 'slime-lisp-implementations
                  '(sbcl ("sbcl") :coding-system utf-8-unix)))

--- a/lisp/init-company.el
+++ b/lisp/init-company.el
@@ -10,7 +10,7 @@
 
 (when (maybe-require-package 'company)
   (add-hook 'after-init-hook 'global-company-mode)
-  (after-load 'company
+  (with-eval-after-load 'company
     (dolist (backend '(company-eclim company-semantic))
       (delq backend company-backends))
     (diminish 'company-mode)
@@ -26,8 +26,8 @@
 
 ;; Suspend page-break-lines-mode while company menu is active
 ;; (see https://github.com/company-mode/company-mode/issues/416)
-(after-load 'company
-  (after-load 'page-break-lines
+(with-eval-after-load 'company
+  (with-eval-after-load 'page-break-lines
     (defvar-local sanityinc/page-break-lines-on-p nil)
 
     (defun sanityinc/page-break-lines-disable (&rest ignore)

--- a/lisp/init-compile.el
+++ b/lisp/init-compile.el
@@ -20,14 +20,14 @@
              :buffer buf
              :category 'compilation))))
 
-(after-load 'compile
+(with-eval-after-load 'compile
   (add-hook 'compilation-finish-functions
             'sanityinc/alert-after-compilation-finish))
 
 (defvar sanityinc/last-compilation-buffer nil
   "The last buffer in which compilation took place.")
 
-(after-load 'compile
+(with-eval-after-load 'compile
   (defun sanityinc/save-compilation-buffer (&rest _)
     "Save the compilation buffer to find it later."
     (setq sanityinc/last-compilation-buffer next-error-last-buffer))
@@ -55,7 +55,7 @@
 (advice-add 'shell-command-on-region :after 'sanityinc/shell-command-in-view-mode)
 
 
-(after-load 'compile
+(with-eval-after-load 'compile
   (require 'ansi-color)
   (defun sanityinc/colourise-compilation-buffer ()
     (when (eq major-mode 'compilation-mode)

--- a/lisp/init-css.el
+++ b/lisp/init-css.el
@@ -10,7 +10,7 @@
 
 ;;; Embedding in html
 (require-package 'mmm-mode)
-(after-load 'mmm-vars
+(with-eval-after-load 'mmm-vars
   (mmm-add-group
    'html-css
    '((css-cdata

--- a/lisp/init-dired.el
+++ b/lisp/init-dired.el
@@ -9,7 +9,7 @@
   (when gls (setq insert-directory-program gls)))
 
 (when (maybe-require-package 'diredfl)
-  (after-load 'dired
+  (with-eval-after-load 'dired
     (diredfl-global-mode)
     (require 'dired-x)))
 
@@ -17,13 +17,13 @@
 (define-key ctl-x-map "\C-j" 'dired-jump)
 (define-key ctl-x-4-map "\C-j" 'dired-jump-other-window)
 
-(after-load 'dired
+(with-eval-after-load 'dired
   (setq dired-recursive-deletes 'top)
   (define-key dired-mode-map [mouse-2] 'dired-find-file)
   (define-key dired-mode-map (kbd "C-c C-q") 'wdired-change-to-wdired-mode))
 
 (when (maybe-require-package 'diff-hl)
-  (after-load 'dired
+  (with-eval-after-load 'dired
     (add-hook 'dired-mode-hook 'diff-hl-dired-mode)))
 
 (provide 'init-dired)

--- a/lisp/init-direnv.el
+++ b/lisp/init-direnv.el
@@ -8,7 +8,7 @@
     (envrc-global-mode)))
 
 (when (maybe-require-package 'envrc)
-  (after-load 'envrc
+  (with-eval-after-load 'envrc
     (define-key envrc-mode-map (kbd "C-c e") 'envrc-command-map))
   (add-hook 'after-init-hook 'sanityinc/maybe-enable-envrc-global-mode))
 

--- a/lisp/init-editing-utils.el
+++ b/lisp/init-editing-utils.el
@@ -38,7 +38,7 @@
 (add-hook 'after-init-hook 'global-auto-revert-mode)
 (setq global-auto-revert-non-file-buffers t
       auto-revert-verbose nil)
-(after-load 'autorevert
+(with-eval-after-load 'autorevert
   (diminish 'auto-revert-mode))
 
 (add-hook 'after-init-hook 'transient-mark-mode)
@@ -84,7 +84,7 @@
 
 
 
-(after-load 'subword
+(with-eval-after-load 'subword
   (diminish 'subword-mode))
 
 
@@ -110,7 +110,7 @@
 (when (maybe-require-package 'symbol-overlay)
   (dolist (hook '(prog-mode-hook html-mode-hook yaml-mode-hook conf-mode-hook))
     (add-hook hook 'symbol-overlay-mode))
-  (after-load 'symbol-overlay
+  (with-eval-after-load 'symbol-overlay
     (diminish 'symbol-overlay-mode)
     (define-key symbol-overlay-mode-map (kbd "M-i") 'symbol-overlay-put)
     (define-key symbol-overlay-mode-map (kbd "M-I") 'symbol-overlay-remove-all)
@@ -128,11 +128,11 @@
 (require-package 'browse-kill-ring)
 (setq browse-kill-ring-separator "\f")
 (global-set-key (kbd "M-Y") 'browse-kill-ring)
-(after-load 'browse-kill-ring
+(with-eval-after-load 'browse-kill-ring
   (define-key browse-kill-ring-mode-map (kbd "C-g") 'browse-kill-ring-quit)
   (define-key browse-kill-ring-mode-map (kbd "M-n") 'browse-kill-ring-forward)
   (define-key browse-kill-ring-mode-map (kbd "M-p") 'browse-kill-ring-previous))
-(after-load 'page-break-lines
+(with-eval-after-load 'page-break-lines
   (add-to-list 'page-break-lines-modes 'browse-kill-ring-mode))
 
 
@@ -211,7 +211,7 @@
 ;;----------------------------------------------------------------------------
 (when (maybe-require-package 'page-break-lines)
   (add-hook 'after-init-hook 'global-page-break-lines-mode)
-  (after-load 'page-break-lines
+  (with-eval-after-load 'page-break-lines
     (diminish 'page-break-lines-mode)))
 
 ;;----------------------------------------------------------------------------
@@ -248,7 +248,7 @@
 ;;----------------------------------------------------------------------------
 (require-package 'whole-line-or-region)
 (add-hook 'after-init-hook 'whole-line-or-region-global-mode)
-(after-load 'whole-line-or-region
+(with-eval-after-load 'whole-line-or-region
   (diminish 'whole-line-or-region-local-mode))
 
 
@@ -333,7 +333,7 @@ With arg N, insert N newlines."
 (require-package 'which-key)
 (add-hook 'after-init-hook 'which-key-mode)
 (setq-default which-key-idle-delay 1.5)
-(after-load 'which-key
+(with-eval-after-load 'which-key
   (diminish 'which-key-mode))
 
 

--- a/lisp/init-elm.el
+++ b/lisp/init-elm.el
@@ -3,15 +3,15 @@
 ;;; Code:
 
 (when (maybe-require-package 'elm-mode)
-  (after-load 'elm-mode
+  (with-eval-after-load 'elm-mode
     (diminish 'elm-indent-mode)
-    (after-load 'company
+    (with-eval-after-load 'company
       (add-to-list 'company-backends 'company-elm))
     (when (executable-find "elm-format")
       (setq-default elm-format-on-save t)))
   (maybe-require-package 'elm-test-runner)
   (when (maybe-require-package 'flycheck-elm)
-    (after-load 'elm-mode
+    (with-eval-after-load 'elm-mode
       (flycheck-elm-setup)))
   (when (maybe-require-package 'add-node-modules-path)
     (add-hook 'elm-mode-hook 'add-node-modules-path)))

--- a/lisp/init-exec-path.el
+++ b/lisp/init-exec-path.el
@@ -4,7 +4,7 @@
 
 (require-package 'exec-path-from-shell)
 
-(after-load 'exec-path-from-shell
+(with-eval-after-load 'exec-path-from-shell
   (dolist (var '("SSH_AUTH_SOCK" "SSH_AGENT_PID" "GPG_AGENT_INFO" "LANG" "LC_CTYPE" "NIX_SSL_CERT_FILE" "NIX_PATH"))
     (add-to-list 'exec-path-from-shell-variables var)))
 

--- a/lisp/init-folding.el
+++ b/lisp/init-folding.el
@@ -3,7 +3,7 @@
 ;;; Code:
 
 (when (maybe-require-package 'origami)
-  (after-load 'origami
+  (with-eval-after-load 'origami
     (define-key origami-mode-map (kbd "C-c f") 'origami-recursively-toggle-node)
     (define-key origami-mode-map (kbd "C-c F") 'origami-toggle-all-nodes)))
 

--- a/lisp/init-git.el
+++ b/lisp/init-git.el
@@ -33,17 +33,17 @@
           (magit-log-buffer-file t))
       (vc-print-log)))
 
-  (after-load 'vc
+  (with-eval-after-load 'vc
     (define-key vc-prefix-map (kbd "l") 'sanityinc/magit-or-vc-log-file)))
 
 
-(after-load 'magit
+(with-eval-after-load 'magit
   (define-key magit-status-mode-map (kbd "C-M-<up>") 'magit-section-up))
 
 (maybe-require-package 'magit-todos)
 
 (require-package 'fullframe)
-(after-load 'magit
+(with-eval-after-load 'magit
   (fullframe magit-status magit-mode-quit-window))
 
 (when (maybe-require-package 'git-commit)
@@ -51,13 +51,13 @@
 
 
 (when *is-a-mac*
-  (after-load 'magit
+  (with-eval-after-load 'magit
     (add-hook 'magit-mode-hook (lambda () (local-unset-key [(meta h)])))))
 
 
 
 ;; Convenient binding for vc-git-grep
-(after-load 'vc
+(with-eval-after-load 'vc
   (define-key vc-prefix-map (kbd "f") 'vc-git-grep))
 
 
@@ -72,7 +72,7 @@
 ;;       (magit-svn-mode)))
 ;;   (add-hook 'magit-status-mode-hook #'sanityinc/maybe-enable-magit-svn-mode))
 
-(after-load 'compile
+(with-eval-after-load 'compile
   (dolist (defn (list '(git-svn-updated "^\t[A-Z]\t\\(.*\\)$" 1 nil nil 0 1)
                       '(git-svn-needs-update "^\\(.*\\): needs update$" 1 nil nil 2 1)))
     (add-to-list 'compilation-error-regexp-alist-alist defn)

--- a/lisp/init-grep.el
+++ b/lisp/init-grep.el
@@ -9,7 +9,7 @@
   (setq-default locate-command "mdfind"))
 
 (require-package 'wgrep)
-(after-load 'grep
+(with-eval-after-load 'grep
   (dolist (key (list (kbd "C-c C-q") (kbd "w")))
     (define-key grep-mode-map key 'wgrep-change-to-wgrep-mode)))
 

--- a/lisp/init-haml.el
+++ b/lisp/init-haml.el
@@ -4,7 +4,7 @@
 
 (require-package 'haml-mode)
 
-(after-load 'haml-mode
+(with-eval-after-load 'haml-mode
   (define-key haml-mode-map (kbd "C-o") 'open-line))
 
 (provide 'init-haml)

--- a/lisp/init-haskell.el
+++ b/lisp/init-haskell.el
@@ -8,7 +8,7 @@
 
   (when (maybe-require-package 'dante)
     (add-hook 'haskell-mode-hook 'dante-mode)
-    (after-load 'dante
+    (with-eval-after-load 'dante
       (flycheck-add-next-checker 'haskell-dante
                                  '(warning . haskell-hlint))))
 
@@ -31,12 +31,12 @@
 
     (defalias 'hindent-mode 'hindent-on-save-mode))
 
-  (after-load 'haskell-mode
+  (with-eval-after-load 'haskell-mode
     (define-key haskell-mode-map (kbd "C-c h") 'hoogle)
     (define-key haskell-mode-map (kbd "C-o") 'open-line))
 
 
-  (after-load 'page-break-lines
+  (with-eval-after-load 'page-break-lines
     (add-to-list 'page-break-lines-modes 'haskell-mode)))
 
 

--- a/lisp/init-html.el
+++ b/lisp/init-html.el
@@ -6,7 +6,7 @@
 ;;; Code:
 
 (require-package 'tagedit)
-(after-load 'sgml-mode
+(with-eval-after-load 'sgml-mode
   (tagedit-add-paredit-like-keybindings)
   (define-key tagedit-mode-map (kbd "M-?") nil)
   (define-key tagedit-mode-map (kbd "M-s") nil)

--- a/lisp/init-ibuffer.el
+++ b/lisp/init-ibuffer.el
@@ -7,7 +7,7 @@
 ;;; Code:
 
 (require-package 'fullframe)
-(after-load 'ibuffer
+(with-eval-after-load 'ibuffer
  (fullframe ibuffer ibuffer-quit))
 
 (require-package 'ibuffer-vc)
@@ -22,7 +22,7 @@
 (setq-default ibuffer-show-empty-filter-groups nil)
 
 
-(after-load 'ibuffer
+(with-eval-after-load 'ibuffer
   ;; Use human readable Size column instead of original one
   (define-ibuffer-column size-h
     (:name "Size" :inline t)

--- a/lisp/init-isearch.el
+++ b/lisp/init-isearch.el
@@ -9,7 +9,7 @@
   (global-set-key [remap query-replace-regexp] 'anzu-query-replace-regexp)
   (global-set-key [remap query-replace] 'anzu-query-replace))
 
-(after-load 'isearch
+(with-eval-after-load 'isearch
   ;; DEL during isearch should edit the search string, not jump back to the previous result
   (define-key isearch-mode-map [remap isearch-delete-char] 'isearch-del-char)
 

--- a/lisp/init-ivy.el
+++ b/lisp/init-ivy.el
@@ -4,7 +4,7 @@
 
 (when (maybe-require-package 'ivy)
   (add-hook 'after-init-hook 'ivy-mode)
-  (after-load 'ivy
+  (with-eval-after-load 'ivy
     (setq-default ivy-use-virtual-buffers t
                   ivy-virtual-abbreviate 'fullpath
                   ivy-count-format ""
@@ -29,18 +29,18 @@
     (setq ivy-virtual-abbreviate 'abbreviate
           ivy-rich-switch-buffer-align-virtual-buffer nil
           ivy-rich-path-style 'abbrev)
-    (after-load 'ivy
+    (with-eval-after-load 'ivy
       (setcdr (assq t ivy-format-functions-alist) #'ivy-format-function-line))
     (add-hook 'ivy-mode-hook (lambda () (ivy-rich-mode ivy-mode)))))
 
 (when (maybe-require-package 'counsel)
   (setq-default counsel-mode-override-describe-bindings t)
-  (after-load 'counsel
+  (with-eval-after-load 'counsel
     (setq-default ivy-initial-inputs-alist
                   '((Man-completion-table . "^")
                     (woman . "^"))))
   (when (maybe-require-package 'diminish)
-    (after-load 'counsel
+    (with-eval-after-load 'counsel
       (diminish 'counsel-mode)))
   (add-hook 'after-init-hook 'counsel-mode)
 
@@ -67,13 +67,13 @@ instead."
                            (projectile-project-root)
                          (error default-directory)))))
             (funcall search-function initial-input dir)))))
-    (after-load 'ivy
+    (with-eval-after-load 'ivy
       (add-to-list 'ivy-height-alist (cons 'counsel-ag 20)))
     (global-set-key (kbd "M-?") 'sanityinc/counsel-search-project)))
 
 
 (when (maybe-require-package 'swiper)
-  (after-load 'ivy
+  (with-eval-after-load 'ivy
     (define-key ivy-mode-map (kbd "M-s /") 'swiper-thing-at-point)))
 
 

--- a/lisp/init-javascript.el
+++ b/lisp/init-javascript.el
@@ -17,7 +17,7 @@
 
 ;; Change some defaults: customize them to override
 (setq-default js2-bounce-indent-p nil)
-(after-load 'js2-mode
+(with-eval-after-load 'js2-mode
   ;; Disable js2 mode's syntax error highlighting by default...
   (setq-default js2-mode-show-parse-errors nil
                 js2-mode-show-strict-warnings nil)
@@ -44,7 +44,7 @@
 
 (when (and (executable-find "ag")
            (maybe-require-package 'xref-js2))
-  (after-load 'js2-mode
+  (with-eval-after-load 'js2-mode
     (define-key js2-mode-map (kbd "M-.") nil)
     (add-hook 'js2-mode-hook
               (lambda () (add-hook 'xref-backend-functions #'xref-js2-xref-backend nil t)))))
@@ -53,7 +53,7 @@
 
 ;;; Coffeescript
 
-(after-load 'coffee-mode
+(with-eval-after-load 'coffee-mode
   (setq-default coffee-js-mode 'js2-mode
                 coffee-tab-width js-indent-level))
 
@@ -83,16 +83,16 @@
 ;; ---------------------------------------------------------------------------
 
 (when (maybe-require-package 'skewer-mode)
-  (after-load 'skewer-mode
+  (with-eval-after-load 'skewer-mode
     (add-hook 'skewer-mode-hook
               (lambda () (inferior-js-keys-mode -1)))))
 
 
 
 (when (maybe-require-package 'add-node-modules-path)
-  (after-load 'typescript-mode
+  (with-eval-after-load 'typescript-mode
     (add-hook 'typescript-mode-hook 'add-node-modules-path))
-  (after-load 'js2-mode
+  (with-eval-after-load 'js2-mode
     (add-hook 'js2-mode-hook 'add-node-modules-path)))
 
 

--- a/lisp/init-ledger.el
+++ b/lisp/init-ledger.el
@@ -4,18 +4,18 @@
 
 (when (maybe-require-package 'ledger-mode)
   (when (maybe-require-package 'flycheck-ledger)
-    (after-load 'flycheck
-      (after-load 'ledger-mode
+    (with-eval-after-load 'flycheck
+      (with-eval-after-load 'ledger-mode
         (require 'flycheck-ledger))))
 
-  (after-load 'ledger-mode
+  (with-eval-after-load 'ledger-mode
     (define-key ledger-mode-map (kbd "RET") 'newline)
     (define-key ledger-mode-map (kbd "C-o") 'open-line))
 
   (setq ledger-highlight-xact-under-point nil
         ledger-use-iso-dates nil)
 
-  (after-load 'ledger-mode
+  (with-eval-after-load 'ledger-mode
     (when (memq window-system '(mac ns))
       (exec-path-from-shell-copy-env "LEDGER_FILE")))
 

--- a/lisp/init-lisp.el
+++ b/lisp/init-lisp.el
@@ -287,10 +287,7 @@ there is no current file, eval the current buffer."
 (maybe-require-package 'cl-libify)
 
 
-(when (maybe-require-package 'flycheck-relint)
-  (after-load 'flycheck
-    (after-load 'elisp-mode
-      (flycheck-relint-setup))))
+(maybe-require-package 'flycheck-relint)
 
 
 

--- a/lisp/init-lisp.el
+++ b/lisp/init-lisp.el
@@ -37,7 +37,7 @@
 
 (global-set-key [remap eval-expression] 'pp-eval-expression)
 
-(after-load 'lisp-mode
+(with-eval-after-load 'lisp-mode
   (define-key emacs-lisp-mode-map (kbd "C-x C-e") 'sanityinc/eval-last-sexp-or-region))
 
 (when (maybe-require-package 'ipretty)
@@ -68,7 +68,7 @@ there is no current file, eval the current buffer."
       (eval-buffer)
       (message "Evaluated %s" (current-buffer)))))
 
-(after-load 'lisp-mode
+(with-eval-after-load 'lisp-mode
   (define-key emacs-lisp-mode-map (kbd "C-c C-l") 'sanityinc/load-this-file))
 
 
@@ -106,9 +106,9 @@ there is no current file, eval the current buffer."
       (funcall sanityinc/repl-switch-function sanityinc/repl-original-buffer)
     (error "No original buffer")))
 
-(after-load 'elisp-mode
+(with-eval-after-load 'elisp-mode
   (define-key emacs-lisp-mode-map (kbd "C-c C-z") 'sanityinc/switch-to-ielm))
-(after-load 'ielm
+(with-eval-after-load 'ielm
   (define-key ielm-map (kbd "C-c C-z") 'sanityinc/repl-switch-back))
 
 ;; ----------------------------------------------------------------------------
@@ -204,7 +204,7 @@ there is no current file, eval the current buffer."
 (add-to-list 'auto-mode-alist '("archive-contents\\'" . emacs-lisp-mode))
 
 (require-package 'cl-lib-highlight)
-(after-load 'lisp-mode
+(with-eval-after-load 'lisp-mode
   (cl-lib-highlight-initialize))
 
 ;; ----------------------------------------------------------------------------
@@ -245,7 +245,7 @@ there is no current file, eval the current buffer."
 
 (require-package 'macrostep)
 
-(after-load 'lisp-mode
+(with-eval-after-load 'lisp-mode
   (define-key emacs-lisp-mode-map (kbd "C-c x") 'macrostep-expand))
 
 
@@ -262,7 +262,7 @@ there is no current file, eval the current buffer."
       (rainbow-mode)))
   (add-hook 'emacs-lisp-mode-hook 'sanityinc/enable-rainbow-mode-if-theme)
   (add-hook 'help-mode-hook 'rainbow-mode)
-  (after-load 'rainbow-mode
+  (with-eval-after-load 'rainbow-mode
     (diminish 'rainbow-mode)))
 
 
@@ -273,14 +273,14 @@ there is no current file, eval the current buffer."
 
 (when (maybe-require-package 'flycheck)
   (require-package 'flycheck-package)
-  (after-load 'flycheck
-    (after-load 'elisp-mode
+  (with-eval-after-load 'flycheck
+    (with-eval-after-load 'elisp-mode
       (flycheck-package-setup))))
 
 
 
 ;; ERT
-(after-load 'ert
+(with-eval-after-load 'ert
   (define-key ert-results-mode-map (kbd "g") 'ert-results-rerun-all-tests))
 
 

--- a/lisp/init-markdown.el
+++ b/lisp/init-markdown.el
@@ -4,7 +4,7 @@
 
 (when (maybe-require-package 'markdown-mode)
   (add-auto-mode 'markdown-mode "\\.md\\.html\\'")
-  (after-load 'whitespace-cleanup-mode
+  (with-eval-after-load 'whitespace-cleanup-mode
     (add-to-list 'whitespace-cleanup-mode-ignore-modes 'markdown-mode)))
 
 

--- a/lisp/init-misc.el
+++ b/lisp/init-misc.el
@@ -26,12 +26,12 @@
 
 
 (when (maybe-require-package 'info-colors)
-  (after-load 'info
+  (with-eval-after-load 'info
     (add-hook 'Info-selection-hook 'info-colors-fontify-node)))
 
 
 ;; Handle the prompt pattern for the 1password command-line interface
-(after-load 'comint
+(with-eval-after-load 'comint
   (setq comint-password-prompt-regexp
         (concat
          comint-password-prompt-regexp
@@ -42,7 +42,7 @@
 (when (maybe-require-package 'regex-tool)
   (setq-default regex-tool-backend 'perl))
 
-(after-load 're-builder
+(with-eval-after-load 're-builder
   ;; Support a slightly more idiomatic quit binding in re-builder
   (define-key reb-mode-map (kbd "C-c C-k") 'reb-quit))
 

--- a/lisp/init-nim.el
+++ b/lisp/init-nim.el
@@ -4,8 +4,8 @@
 
 (when (maybe-require-package 'nim-mode)
   (when (maybe-require-package 'flycheck-nim)
-    (after-load 'nim-mode
-      (after-load 'flycheck
+    (with-eval-after-load 'nim-mode
+      (with-eval-after-load 'flycheck
         (require 'flycheck-nim)))))
 
 (provide 'init-nim)

--- a/lisp/init-nix.el
+++ b/lisp/init-nix.el
@@ -9,10 +9,10 @@
 
   (when (maybe-require-package 'nixos-options)
     (when (maybe-require-package 'company-nixos-options)
-      (after-load 'company
+      (with-eval-after-load 'company
 
         ;; Patch pending https://github.com/travisbhartwell/nix-emacs/pull/46
-        (after-load 'company-nixos-options
+        (with-eval-after-load 'company-nixos-options
           (defun company-nixos--in-nix-context-p ()
             (unless (executable-find "nix-build")
               (or (derived-mode-p 'nix-mode 'nix-repl-mode)

--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -55,7 +55,7 @@
 ;; Lots of stuff from http://doc.norang.ca/org-mode.html
 
 ;; Re-align tags when window shape changes
-(after-load 'org-agenda
+(with-eval-after-load 'org-agenda
   (add-hook 'org-agenda-mode-hook
             (lambda () (add-hook 'window-configuration-change-hook 'org-agenda-align-tags nil t))))
 
@@ -126,7 +126,7 @@ typical word processor."
 ;; Targets include this file and any file contributing to the agenda - up to 5 levels deep
 (setq org-refile-targets '((nil :maxlevel . 5) (org-agenda-files :maxlevel . 5)))
 
-(after-load 'org-agenda
+(with-eval-after-load 'org-agenda
   (add-to-list 'org-agenda-after-show-hook 'org-show-entry))
 
 (advice-add 'org-refile :after (lambda (&rest _) (org-save-all-org-buffers)))
@@ -267,7 +267,7 @@ typical word processor."
 ;;; Org clock
 
 ;; Save the running clock and all clock history when exiting Emacs, load it on startup
-(after-load 'org
+(with-eval-after-load 'org
   (org-clock-persistence-insinuate))
 (setq org-clock-persist t)
 (setq org-clock-in-resume t)
@@ -296,7 +296,7 @@ typical word processor."
 (add-hook 'org-clock-out-hook 'sanityinc/hide-org-clock-from-header-line)
 (add-hook 'org-clock-cancel-hook 'sanityinc/hide-org-clock-from-header-line)
 
-(after-load 'org-clock
+(with-eval-after-load 'org-clock
   (define-key org-clock-mode-line-map [header-line mouse-2] 'org-clock-goto)
   (define-key org-clock-mode-line-map [header-line mouse-1] 'org-clock-menu))
 
@@ -328,7 +328,7 @@ typical word processor."
 
 (require-package 'org-pomodoro)
 (setq org-pomodoro-keep-killed-pomodoro-time t)
-(after-load 'org-agenda
+(with-eval-after-load 'org-agenda
   (define-key org-agenda-mode-map (kbd "P") 'org-pomodoro))
 
 
@@ -353,13 +353,13 @@ typical word processor."
 ;;                 (insert (match-string 0))))))
 
 
-(after-load 'org
+(with-eval-after-load 'org
   (define-key org-mode-map (kbd "C-M-<up>") 'org-up-element)
   (when *is-a-mac*
     (define-key org-mode-map (kbd "M-h") nil)
     (define-key org-mode-map (kbd "C-c g") 'org-mac-grab-link)))
 
-(after-load 'org
+(with-eval-after-load 'org
   (org-babel-do-load-languages
    'org-babel-load-languages
    `((R . t)

--- a/lisp/init-osx-keys.el
+++ b/lisp/init-osx-keys.el
@@ -15,7 +15,7 @@
   (global-set-key (kbd "M-`") 'ns-next-frame)
   (global-set-key (kbd "M-h") 'ns-do-hide-emacs)
   (global-set-key (kbd "M-˙") 'ns-do-hide-others)
-  (after-load 'nxml-mode
+  (with-eval-after-load 'nxml-mode
     (define-key nxml-mode-map (kbd "M-h") nil))
   (global-set-key (kbd "M-ˍ") 'ns-do-hide-others) ;; what describe-key reports for cmd-option-h
   )

--- a/lisp/init-paredit.el
+++ b/lisp/init-paredit.el
@@ -11,7 +11,7 @@
 
 (add-hook 'paredit-mode-hook 'maybe-map-paredit-newline)
 
-(after-load 'paredit
+(with-eval-after-load 'paredit
   (diminish 'paredit-mode " Par")
   ;; Suppress certain paredit keybindings to avoid clashes, including
   ;; my global binding of M-?

--- a/lisp/init-php.el
+++ b/lisp/init-php.el
@@ -6,7 +6,7 @@
   (maybe-require-package 'smarty-mode)
 
   (when (maybe-require-package 'company-php)
-    (after-load 'company
+    (with-eval-after-load 'company
       (add-to-list 'company-backends 'company-ac-php-backend))))
 
 (provide 'init-php)

--- a/lisp/init-projectile.el
+++ b/lisp/init-projectile.el
@@ -8,7 +8,7 @@
   ;; Shorter modeline
   (setq-default projectile-mode-line-prefix " Proj")
 
-  (after-load 'projectile
+  (with-eval-after-load 'projectile
     (define-key projectile-mode-map (kbd "C-c p") 'projectile-command-map))
 
   (maybe-require-package 'ibuffer-projectile))

--- a/lisp/init-projectile.el
+++ b/lisp/init-projectile.el
@@ -8,6 +8,9 @@
   ;; Shorter modeline
   (setq-default projectile-mode-line-prefix " Proj")
 
+  (when (executable-find "rg")
+    (setq-default projectile-generic-command "rg --files --hidden"))
+
   (with-eval-after-load 'projectile
     (define-key projectile-mode-map (kbd "C-c p") 'projectile-command-map))
 

--- a/lisp/init-purescript.el
+++ b/lisp/init-purescript.el
@@ -11,7 +11,7 @@
 
   (add-hook 'purescript-mode-hook (apply-partially 'prettify-symbols-mode -1))
 
-  (after-load 'purescript-mode
+  (with-eval-after-load 'purescript-mode
     (define-key purescript-mode-map (kbd "C-o") 'open-line))
 
   (when (maybe-require-package 'reformatter)
@@ -56,9 +56,9 @@ corresponding .purs file is open."
     (add-hook 'purescript-mode-hook 'inferior-psci-mode))
 
   (when (maybe-require-package 'add-node-modules-path)
-    (after-load 'purescript-mode
+    (with-eval-after-load 'purescript-mode
       (add-hook 'purescript-mode-hook 'add-node-modules-path))
-    (after-load 'psci
+    (with-eval-after-load 'psci
       (advice-add 'psci :around (lambda (oldfun &rest args)
                                   (let ((psci/purs-path (or (executable-find "purs")
                                                             psci/purs-path)))

--- a/lisp/init-python.el
+++ b/lisp/init-python.el
@@ -18,18 +18,18 @@
 (require-package 'pip-requirements)
 
 (when (maybe-require-package 'anaconda-mode)
-  (after-load 'python
+  (with-eval-after-load 'python
     ;; Anaconda doesn't work on remote servers without some work, so
     ;; by default we enable it only when working locally.
     (add-hook 'python-mode-hook
               (lambda () (unless (file-remote-p default-directory)
                       (anaconda-mode 1))))
     (add-hook 'anaconda-mode-hook 'anaconda-eldoc-mode))
-  (after-load 'anaconda-mode
+  (with-eval-after-load 'anaconda-mode
     (define-key anaconda-mode-map (kbd "M-?") nil))
   (when (maybe-require-package 'company-anaconda)
-    (after-load 'company
-      (after-load 'python
+    (with-eval-after-load 'company
+      (with-eval-after-load 'python
         (add-to-list 'company-backends 'company-anaconda)))))
 
 (when (maybe-require-package 'toml-mode)

--- a/lisp/init-ruby.el
+++ b/lisp/init-ruby.el
@@ -17,7 +17,7 @@
 
 (add-hook 'ruby-mode-hook 'subword-mode)
 
-(after-load 'page-break-lines
+(with-eval-after-load 'page-break-lines
   (add-to-list 'page-break-lines-modes 'ruby-mode))
 
 (require-package 'rspec-mode)
@@ -37,21 +37,21 @@
 ;;; Ruby compilation
 (require-package 'ruby-compilation)
 
-(after-load 'ruby-mode
+(with-eval-after-load 'ruby-mode
   (define-key ruby-mode-map [S-f7] 'ruby-compilation-this-buffer)
   (define-key ruby-mode-map [f7] 'ruby-compilation-this-test))
 
-(after-load 'ruby-compilation
+(with-eval-after-load 'ruby-compilation
   (defalias 'rake 'ruby-compilation-rake))
 
 
 
 ;;; Robe
 (when (maybe-require-package 'robe)
-  (after-load 'ruby-mode
+  (with-eval-after-load 'ruby-mode
     (add-hook 'ruby-mode-hook 'robe-mode))
-  (after-load 'robe
-    (after-load 'company
+  (with-eval-after-load 'robe
+    (with-eval-after-load 'company
       (add-to-list 'company-backends 'company-robe))))
 
 
@@ -67,7 +67,7 @@
 
 (when (maybe-require-package 'yard-mode)
   (add-hook 'ruby-mode-hook 'yard-mode)
-  (after-load 'yard-mode
+  (with-eval-after-load 'yard-mode
     (diminish 'yard-mode)))
 
 

--- a/lisp/init-rust.el
+++ b/lisp/init-rust.el
@@ -9,7 +9,7 @@
     (add-hook 'racer-mode-hook #'company-mode)))
 
 (when (maybe-require-package 'flycheck-rust)
-  (after-load 'rust-mode
+  (with-eval-after-load 'rust-mode
     (add-hook 'flycheck-mode-hook #'flycheck-rust-setup)))
 
 (provide 'init-rust)

--- a/lisp/init-slime.el
+++ b/lisp/init-slime.el
@@ -19,7 +19,7 @@
   "Mode setup function for slime lisp buffers."
   (set-up-slime-hippie-expand))
 
-(after-load 'slime
+(with-eval-after-load 'slime
   (setq slime-protocol-version 'ignore)
   (setq slime-net-coding-system 'utf-8-unix)
   (let ((extras (when (require 'slime-company nil t)
@@ -37,9 +37,9 @@
   (sanityinc/lisp-setup)
   (set-up-slime-hippie-expand))
 
-(after-load 'slime-repl
+(with-eval-after-load 'slime-repl
   ;; Stop SLIME's REPL from grabbing DEL, which is annoying when backspacing over a '('
-  (after-load 'paredit
+  (with-eval-after-load 'paredit
     (define-key slime-repl-mode-map (read-kbd-macro paredit-backward-delete-key) nil))
 
   ;; Bind TAB to `indent-for-tab-command', as in regular Slime buffers.

--- a/lisp/init-spelling.el
+++ b/lisp/init-spelling.el
@@ -8,7 +8,7 @@
   ;; Add spell-checking in comments for all programming language modes
   (add-hook 'prog-mode-hook 'flyspell-prog-mode)
 
-  (after-load 'flyspell
+  (with-eval-after-load 'flyspell
     (define-key flyspell-mode-map (kbd "C-;") nil)
     (add-to-list 'flyspell-prog-text-faces 'nxml-text-face)))
 

--- a/lisp/init-sql.el
+++ b/lisp/init-sql.el
@@ -2,7 +2,7 @@
 ;;; Commentary:
 ;;; Code:
 
-(after-load 'sql
+(with-eval-after-load 'sql
   ;; sql-mode pretty much requires your psql to be uncustomised from stock settings
   (add-to-list 'sql-postgres-options "--no-psqlrc"))
 
@@ -26,7 +26,7 @@ Fix for the above hasn't been released as of Emacs 25.2."
     (when sql-buffer
       (sanityinc/pop-to-sqli-buffer))))
 
-(after-load 'sql
+(with-eval-after-load 'sql
   (define-key sql-mode-map (kbd "C-c C-z") 'sanityinc/pop-to-sqli-buffer)
   (when (package-installed-p 'dash-at-point)
     (defun sanityinc/maybe-set-dash-db-docset (&rest _)
@@ -48,7 +48,7 @@ Fix for the above hasn't been released as of Emacs 25.2."
 
 
 (require-package 'sqlformat)
-(after-load 'sql
+(with-eval-after-load 'sql
   (define-key sql-mode-map (kbd "C-c C-f") 'sqlformat))
 
 ;; Package ideas:
@@ -112,12 +112,12 @@ This command currently blocks the UI, sorry."
 
 
 ;; Submitted upstream as https://github.com/stanaka/dash-at-point/pull/28
-(after-load 'sql
-  (after-load 'dash-at-point
+(with-eval-after-load 'sql
+  (with-eval-after-load 'dash-at-point
     (add-to-list 'dash-at-point-mode-alist '(sql-mode . "psql,mysql,sqlite,postgis"))))
 
 
-(after-load 'page-break-lines
+(with-eval-after-load 'page-break-lines
   (add-to-list 'page-break-lines-modes 'sql-mode))
 
 (provide 'init-sql)

--- a/lisp/init-terraform.el
+++ b/lisp/init-terraform.el
@@ -6,7 +6,7 @@
 
 (when (maybe-require-package 'terraform-mode)
   (when (maybe-require-package 'company-terraform)
-    (after-load 'terraform-mode
+    (with-eval-after-load 'terraform-mode
       (company-terraform-init)
 
       ;; I find formatters based on "reformatter" to be more reliable

--- a/lisp/init-themes.el
+++ b/lisp/init-themes.el
@@ -42,10 +42,10 @@
 (when (maybe-require-package 'dimmer)
   (setq-default dimmer-fraction 0.15)
   (add-hook 'after-init-hook 'dimmer-mode)
-  (after-load 'dimmer
+  (with-eval-after-load 'dimmer
     ;; TODO: file upstream as a PR
     (advice-add 'frame-set-background-mode :after (lambda (&rest args) (dimmer-process-all))))
-  (after-load 'dimmer
+  (with-eval-after-load 'dimmer
     ;; Don't dim in terminal windows. Even with 256 colours it can
     ;; lead to poor contrast.  Better would be to vary dimmer-fraction
     ;; according to frame type.

--- a/lisp/init-utils.el
+++ b/lisp/init-utils.el
@@ -2,14 +2,7 @@
 ;;; Commentary:
 ;;; Code:
 
-(if (fboundp 'with-eval-after-load)
-    (defalias 'after-load 'with-eval-after-load)
-  (defmacro after-load (feature &rest body)
-    "After FEATURE is loaded, evaluate BODY."
-    (declare (indent defun))
-    `(eval-after-load ,feature
-       '(progn ,@body))))
-
+(define-obsolete-function-alias 'after-load 'with-eval-after-load "")
 
 ;;----------------------------------------------------------------------------
 ;; Handier way to add modes to auto-mode-alist

--- a/lisp/init-vc.el
+++ b/lisp/init-vc.el
@@ -10,7 +10,7 @@
   (add-hook 'magit-post-refresh-hook 'diff-hl-magit-post-refresh)
   (add-hook 'after-init-hook 'global-diff-hl-mode)
 
-  (after-load 'diff-hl
+  (with-eval-after-load 'diff-hl
     (define-key diff-hl-mode-map
       (kbd "<left-fringe> <mouse-1>")
       'diff-hl-diff-goto-hunk)))

--- a/lisp/init-whitespace.el
+++ b/lisp/init-whitespace.el
@@ -17,7 +17,7 @@
 
 (require-package 'whitespace-cleanup-mode)
 (add-hook 'after-init-hook 'global-whitespace-cleanup-mode)
-(after-load 'whitespace-cleanup-mode
+(with-eval-after-load 'whitespace-cleanup-mode
   (diminish 'whitespace-cleanup-mode))
 
 (global-set-key [remap just-one-space] 'cycle-spacing)


### PR DESCRIPTION
Don't enable flycheck-relint by default

Don't bother aliasing with-eval-after-load

Use rg (if available) to list files in generic projectile roots